### PR TITLE
Remove reference to Go as being functional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ This will wired your brain in different ways making you more flexible in making 
 
 ---
 
-- **Activity**: Make courses of at least another 3 languages that use another paradigms. As a Ruby developer maybe you have to find some functional oriented language as [Golang](https://golang.org/) or [Elixir](https://elixir-lang.org/), pick up another on your taste.
+- **Activity** Complete courses of at least another 3 languages that use other paradigms. As a Ruby developer maybe you would like to learn a functional language like [Elixir](https://elixir-lang.org/) or a systems language like [Golang](https://golang.org/), pick up another on your taste.
 
 # Community and Communication
 


### PR DESCRIPTION
While one can make the argument that Go supports a "pure" function paradigm (https://golang.org/doc/codewalk/functions/), I believe it lives in the realm of the Imperative (Procedural to be a little more narrow) programming.

A language like Elixir (or Clojure, or Haskell) is a true representative of the style including not just functions as first-class citizens, but bringing immutability, sometimes pattern matching, sometimes tail recursion and other "more functional" aspects to the programming table.

This is a good thread imho: https://www.quora.com/Is-the-programming-language-Go-a-functional-or-object-oriented-programming-language.

wdyt?